### PR TITLE
Fixes to synthesizeMouse calls to click at the center instead of at (1, 1)

### DIFF
--- a/mozmill/mozmill/extension/resource/modules/controller.js
+++ b/mozmill/mozmill/extension/resource/modules/controller.js
@@ -598,7 +598,10 @@ MozMillController.prototype.select = function (el, indx, option, value) {
 
     // Click the item
     try {
-      EventUtils.synthesizeMouse(element, 1, 1, {}, item.ownerDocument.defaultView);
+      var elementRect = element.getBoundingClientRect();
+      EventUtils.synthesizeMouse(element, elementRect.width / 2,
+                                 elementRect.height / 2, {},
+                                 item.ownerDocument.defaultView);
       this.sleep(0);
 
       // Scroll down until item is visible
@@ -611,7 +614,9 @@ MozMillController.prototype.select = function (el, indx, option, value) {
         else if (entry.label == "") i += 1;
       }
 
-      EventUtils.synthesizeMouse(item, 1, 1, {}, item.ownerDocument.defaultView);
+      var itemRect = item.getBoundingClientRect();
+      EventUtils.synthesizeMouse(item, itemRect.width / 2, itemRect.height / 2,
+                                 {}, item.ownerDocument.defaultView);
       this.sleep(0);
 
    frame.events.pass({'function':'Controller.select()'});


### PR DESCRIPTION
See [1] for why this is necessary and [2] for a monkey-patch to Thunderbird that we used to fix the orange caused by [1].

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=595652

[2] http://hg.mozilla.org/comm-central/rev/9bc8d9c9552e
