### PR TITLE
Remove unused nativeJSON variable

### DIFF
--- a/jsbridge/jsbridge/extension/resource/modules/server.js
+++ b/jsbridge/jsbridge/extension/resource/modules/server.js
@@ -50,9 +50,6 @@ var hwindow = Components.classes["@mozilla.org/appshell/appShellService;1"]
     .getService(Components.interfaces.nsIAppShellService)
     .hiddenDOMWindow;
     
-var nativeJSON = Components.classes["@mozilla.org/dom/json;1"]
-    .createInstance(Components.interfaces.nsIJSON);
-
 var json2 = Components.utils.import("resource://jsbridge/modules/json2.js");
 
 var jsonEncode = json2.JSON.stringify;    


### PR DESCRIPTION
This caught my attention because of a TM merge which removed a couple of methods from Ci.nsIJSON and subsequently broke comm-central. I verified through grep that nativeJSON isn't used anywhere.
