### PR TITLE
Bug 709773 - Moving code around in CLI

### DIFF
--- a/mozmill/mozmill/__init__.py
+++ b/mozmill/mozmill/__init__.py
@@ -841,8 +841,7 @@ class ThunderbirdCLI(CLI):
     profile_class = mozrunner.ThunderbirdProfile
     runner_class = mozrunner.ThunderbirdRunner
 
-class ThunderbirdRestartCLI(CLI):
-    mozmill_class = MozMillRestart
+class ThunderbirdRestartCLI(RestartCLI):
     profile_class = mozrunner.ThunderbirdProfile
     runner_class = mozrunner.ThunderbirdRunner
 
@@ -858,3 +857,6 @@ def tbird_cli():
 
 def restart_cli():
     RestartCLI().run()
+
+def tbird_restart_cli():
+    ThunderbirdRestartCLI().run()


### PR DESCRIPTION
Re: https://bugzilla.mozilla.org/show_bug.cgi?id=709773

Changes were made to the Mozmill 1.5 CLI to allow for access to the test argument after the CLI has been initialized. 
