### PR TITLE
Bug 740773 : Report error if Mozmill validation blocks the data

### DIFF
--- a/mozmill/mozmill/report.py
+++ b/mozmill/mozmill/report.py
@@ -137,7 +137,7 @@ class Report(object):
         connection.close()
 
         # Check if the report has been created
-        if not data['ok']:
+        if not 'ok' in data:
             print "Creating report document failed (%s)" % data
             return data
 


### PR DESCRIPTION
This reports the error message that comes out of the Mozmill Dashboard now. 

It was reporting 
`Sending results to 'http://mozmilldashboard:5984/db' failed (ok).`

and now does

 `INFO | Creating report document failed ({u'reason': u'This document requires the field report_version', u'error': u'forbidden'})`
