### PR TITLE
Bug 748730 - Fix JS error in JSbridge overlay.js for redefining Cu

### DIFF
--- a/jsbridge/jsbridge/extension/chrome/content/overlay.js
+++ b/jsbridge/jsbridge/extension/chrome/content/overlay.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const Cu = Components.utils;
-
 var jsbridgeInit = {}; Cu.import('resource://jsbridge/modules/init.js',jsbridgeInit);
 
 


### PR DESCRIPTION
Silly mistake I haven't seen but breaks JSBridge. Cu is already defined as the Error Console says.
