### PR TITLE
Bug 810627 - elementsLib's radiobutton test causes Application disconnect error

### DIFF
--- a/mozmill/mozmill/extension/content/test/radio_buttons.xul
+++ b/mozmill/mozmill/extension/content/test/radio_buttons.xul
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+
+<?xml-stylesheet href="chrome://global/skin/global.css" type="text/css"?>
+
+<?xml-stylesheet href="chrome://mozapps/content/preferences/preferences.css"?>
+<?xml-stylesheet href="chrome://browser/skin/preferences/preferences.css"?>
+
+<!DOCTYPE window [
+<!ENTITY % mainDTD SYSTEM "chrome://browser/locale/preferences/main.dtd">
+%mainDTD;
+]>
+
+<window id="radio_buttons_test"
+        xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+        title="Radio Buttons Testing Window">
+
+  <groupbox id="downloadsGroup">
+    <caption label="&downloads.label;"/>
+
+    <checkbox id="showWhenDownloading"
+              label="&showWhenDownloading.label;"
+              accesskey="&showWhenDownloading.accesskey;"/>
+    <checkbox id="closeWhenDone"
+              label="&closeWhenDone.label;"
+              accesskey="&closeWhenDone.accesskey;"/>
+
+    <separator class="thin"/>
+
+    <radiogroup id="saveWhere">
+      <hbox id="saveToRow">
+        <radio id="saveTo"
+               value="true"
+               label="&saveTo.label;"
+               accesskey="&saveTo.accesskey;"/>
+        <filefield id="downloadFolder"
+                   flex="1"
+                   aria-labelledby="saveTo"/>
+        <button id="chooseFolder"/>
+      </hbox>
+      <radio id="alwaysAsk"
+             value="false"
+             label="&alwaysAsk.label;"
+             accesskey="&alwaysAsk.accesskey;"/>
+    </radiogroup>
+  </groupbox>
+</window>

--- a/mutt/mutt/tests/js/elementslib/radio_buttons.js
+++ b/mutt/mutt/tests/js/elementslib/radio_buttons.js
@@ -23,9 +23,10 @@ var test = function () {
   expect.ok(radio2.getNode().checked, "Second radio button has been selected.");
 
   // Test chrome (XUL)
-  prefs = mozmill.getPreferencesController();
+  controller.open("chrome://mozmill/content/test/radio_buttons.xul");
+  controller.waitForPageLoad();
 
-  var radiogroup = findElement.ID(prefs.window.document, "saveWhere");
+  var radiogroup = findElement.ID(controller.tabs.activeTab, "saveWhere");
   radiogroup.select(0);
   expect.equal(radiogroup.getNode().selectedIndex, 0, "First radio button has been selected.");
 


### PR DESCRIPTION
This is the **r+**-ed [patch](https://bugzilla.mozilla.org/attachment.cgi?id=680883&action=diff) with addressed [white space nits](https://bugzilla.mozilla.org/show_bug.cgi?id=810627#c12).
See [Bug 810627](https://bugzilla.mozilla.org/show_bug.cgi?id=810627).
