### PR TITLE
Update README.md to remove dead addon link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Automation + Tools Mozmill Repository
 
 [Mozmill](https://developer.mozilla.org/en/Mozmill) is a UI Automation
-framework for Mozilla apps like Firefox and Thunderbird. It's both an
-[addon](https://addons.mozilla.org/en-US/firefox/addon/9018/) and a
-Python command-line tool. 
+framework for Mozilla apps like Firefox and Thunderbird. It takes the form of a
+Python command-line tool.
 
 The [Mozmill repository](http://github.com/mozilla/mozmill)
 contains Mozmill and supporting code which is also used for MozBase
@@ -47,7 +46,7 @@ Each of these packages contains a `README.md` file in markdown syntax
 giving in-depth information on their utility.  These packages all make
 use of
 [setuptools](http://peak.telecommunity.com/DevCenter/setuptools)
-for installation.  It is highly recommended that you use 
+for installation.  It is highly recommended that you use
 [virtualenv](http://www.virtualenv.org/) to keep your python
 environment separate from your system packages.  In this way, you can
 keep multiple versions of packages around without worrying about
@@ -66,7 +65,7 @@ level of the repository to help keep repository management sane:
   packages in the [Mozmill repository](http://github.com/mozilla/mozmill)
   in development mode, respecting dependency order.  This means that
   code changes will be respected the next time the python interpreter
-  is invoked. Using virtualenv, checking out the 
+  is invoked. Using virtualenv, checking out the
   [git repository](http://github.com/mozilla/mozmill), and
   invoking `setup_development.py` with the virtualenv's copy of python
   is the most robust way of deploying the software

--- a/mozmill/README.md
+++ b/mozmill/README.md
@@ -1,26 +1,22 @@
 [Mozmill](https://developer.mozilla.org/en/Mozmill) is a test tool and
 UI automation framework for writing tests and other automation scripts
-for Gecko based applications like Firefox and Thunderbird. 
-It's built as an
-[addon](https://addons.mozilla.org/en-US/firefox/addon/9018/) 
-and a [python](http://python.org) command-line tool. The addon provides an IDE 
-(Integrated Development Environment) for writing and
-running JavaScript tests and the python package provides a
+for Gecko based applications like Firefox and Thunderbird.
+It's built as a [python](http://python.org) command-line tool. The python package provides a
 mechanism for running the tests from the command line as well as
-providing a way to test restarting the application. 
-Mozmill has an extensive API to help you write functional tests that 
+providing a way to test restarting the application.
+Mozmill has an extensive API to help you write functional tests that
 simulate user interactions.
 
 The [Mozmill test automation project](https://wiki.mozilla.org/QA/Mozmill_Test_Automation)
 was started in January 2009 and covers the automation work for
 Firefox. Checkout the [project page](https://wiki.mozilla.org/QA/Mozmill_Test_Automation)
-or have a look at the 
+or have a look at the
 [Mozmill Tests documentation](https://developer.mozilla.org/en/Mozmill_Tests)
-to get an impression of how to contribute in writing and running 
-[Mozmill tests](https://developer.mozilla.org/en/Mozmill_Tests). 
-Existing tests get run in the 
+to get an impression of how to contribute in writing and running
+[Mozmill tests](https://developer.mozilla.org/en/Mozmill_Tests).
+Existing tests get run in the
 [release testing](https://developer.mozilla.org/en/Mozmill/Release_Testing)
-cycle for new major or security releases of Firefox. 
+cycle for new major or security releases of Firefox.
 
 Also the Mozilla Messaging team has an active project which handles
 [Thunderbird Testing with Mozmill](https://developer.mozilla.org/en/Thunderbird/Thunderbird_MozMill_Testing).
@@ -28,26 +24,19 @@ Also the Mozilla Messaging team has an active project which handles
 
 # Installation
 
-Mozmill is available as an addon and a python package.
+Mozmill is available as a python package.
 See [the installation page](./Installation) for instructions for how
 to get Mozmill set up on your system.
 
 
-# The Mozmill Extension
-
-[The Mozmill extension](https://addons.mozilla.org/en-US/firefox/addon/9018)
-comes with an integrated development environment, some test authoring
-tools, and a graphical interface to run the tests. 
-
-
 # Python Client
 
-There is also a [Mozmill python package](http://pypi.python.org/pypi/mozmill) 
-that invokes and runs a Gecko application, performs automatic test scripting,
+The [Mozmill python package](http://pypi.python.org/pypi/mozmill)
+invokes and runs a Gecko application, performs automatic test scripting,
 and accumulates and reports results.
 
 
-## Running the command line client 
+## Running the command line client
 
 After [installing](./Installation)
 the python package you can run Mozmill with the `mozmill` command.


### PR DESCRIPTION
The addon link on the README page leads to a page that says: "This add-on has
been removed by its author.". Furthermore, by searching on Google I was
able to find the following Mozmill Developpers Google Groups message
(https://groups.google.com/forum/#!topic/mozmill-dev/02HwCHWQFRA) that
states the addon was removed because it hadn't been updated in a long
time and support for it had already been dropped.
