### PR TITLE
Fix const usage in mozmill-1.5

### DIFF
--- a/jsbridge/jsbridge/extension/components/cmdarg.js
+++ b/jsbridge/jsbridge/extension/components/cmdarg.js
@@ -119,6 +119,6 @@ jsbridgeHandler.prototype = {
  * XPCOMUtils.generateNSGetModule is for Mozilla 1.9.1 (Firefox 3.5).
  */
 if (XPCOMUtils.generateNSGetFactory)
-  const NSGetFactory = XPCOMUtils.generateNSGetFactory([jsbridgeHandler]);
+  var NSGetFactory = XPCOMUtils.generateNSGetFactory([jsbridgeHandler]);
 else
-  const NSGetModule = XPCOMUtils.generateNSGetModule([jsbridgeHandler]);
+  var NSGetModule = XPCOMUtils.generateNSGetModule([jsbridgeHandler]);


### PR DESCRIPTION
const statements are no longer lifted out of the block they are declared in,
this takes the simplest step and just converts to var.

This is causing AWSY failures. I have my virtualenv patched locally, but I'd much rather get a proper jsbridge fix out.
